### PR TITLE
Factor out dynamo db dependency

### DIFF
--- a/app/resources/api.py
+++ b/app/resources/api.py
@@ -14,6 +14,25 @@ logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(name)s: %(levelname)s %(message)s')
 
 
+class HostSerializer(object):
+
+    @staticmethod
+    def serialize(hosts):
+        '''Makes host dictionary serializable
+
+        :param hosts: list of hosts, each host is defined by dict host info
+        :type hosts: dict
+
+        :returns: list of host info dictionaries
+        :rtype: list of dict
+        '''
+
+        for _host in hosts:
+            _host['last_check_in'] = str(_host['last_check_in'])
+
+        return hosts
+
+
 class Registration(Resource):
 
     def get(self, service):
@@ -23,7 +42,7 @@ class Registration(Resource):
         response = {
             'service': service,
             'env': settings.APPLICATION_ENV,
-            'hosts': hosts
+            'hosts': HostSerializer.serialize(hosts)
         }
         return response, 200
 
@@ -88,7 +107,7 @@ class RepoRegistration(Resource):
         response = {
             'service_repo_name': service_repo_name,
             'env': settings.APPLICATION_ENV,
-            'hosts': hosts
+            'hosts': HostSerializer.serialize(hosts)
         }
         return response, 200
 

--- a/app/resources/api.py
+++ b/app/resources/api.py
@@ -113,13 +113,9 @@ class LoadBalancing(Resource):
         host_service = host.HostService()
 
         if ip_address:
-            try:
-                host_service.set_tag(
-                    service, ip_address, 'load_balancing_weight', weight)
-            except Host.DoesNotExist:
+            if not host_service.set_tag(service, ip_address, 'load_balancing_weight', weight):
                 return {"error": "Host not found"}, 404
         else:
-            host_service.set_tag_all(
-                service, 'load_balancing_weight', weight)
+            host_service.set_tag_all(service, 'load_balancing_weight', weight)
 
         return "", 204

--- a/app/resources/api.py
+++ b/app/resources/api.py
@@ -8,7 +8,6 @@ from flask.ext.restful import Resource
 from ..stats import get_stats
 from .. import settings
 from ..services import host
-from ..models.host import Host
 
 logger = logging.getLogger('resources.api')
 logging.basicConfig(level=logging.DEBUG,

--- a/app/services/query.py
+++ b/app/services/query.py
@@ -301,7 +301,7 @@ class DynamoQueryBackend(QueryBackend):
         _host['service_repo_name'] = host.service_repo_name
         _host['port'] = host.port
         _host['revision'] = host.revision
-        _host['last_check_in'] = host.last_check_in
+        _host['last_check_in'] = str(host.last_check_in)
         _host['tags'] = host.tags
         return _host
 

--- a/app/services/query.py
+++ b/app/services/query.py
@@ -1,0 +1,220 @@
+import abc
+import logging
+import os
+import pickle
+import tempfile
+
+from ..stats import get_stats
+from ..models.host import Host
+
+
+class QueryBackend(object):
+    __metaclass__ = abc.ABCMeta
+    '''A storage backend that can store and retrieve host data.
+
+    This is modeled off of the dynamodb python API, but made more
+    general so users not on Amazon can use discovery.
+    '''
+    @abc.abstractmethod
+    def query(self, service):
+        '''Returns a generator of host dicts for the given service.
+
+        Note that this will NOT deal with how timing out entries -- that is
+        a concern of the caller.
+        '''
+        pass
+
+    @abc.abstractmethod
+    def query_secondary_index(self, service_repo_name):
+        '''For backends that support secondary indices, allows more efficient querying'''
+        pass
+
+    @abc.abstractmethod
+    def get(self, service, ip_address):
+        '''Returns a single value for the given service/ip_address, if one exists, None otherwise'''
+        pass
+
+    @abc.abstractmethod
+    def put(self, host):
+        '''Attempts to store the given host'''
+        pass
+
+    @abc.abstractmethod
+    def delete(self, service, ip_address):
+        '''Deletes the given host for the given service/ip_address, returning True if successful'''
+        pass
+
+    def batch_put(self, hosts):
+        '''Batch write interface for backends which support more efficient batch storing methods'''
+        for host in hosts:
+            self.store(host)
+
+
+# TODO need to factor out the statsd dep
+class MemoryQueryBackend(QueryBackend):
+    def __init__(self):
+        self.data = {}
+
+    def _list_all(self):
+        for service in self.data.keys():
+            for r in self.query(service):
+                yield r
+
+    def query(self, service):
+        ip_map = self.data.get(service)
+        if ip_map is None:
+            return
+
+        for ip_address, host_dict in ip_map.iteritems():
+            _host = host_dict.copy()
+            _host['service'] = service
+            _host['ip_address'] = ip_address
+            yield _host
+
+    # TODO this can certainly be made faster, but I don't know if that's
+    #      really necessary...
+    def query_secondary_index(self, service_repo_name):
+        for host in self._list_all():
+            if host['service_repo_name'] == service_repo_name:
+                yield host
+
+    def get(self, service, ip_address):
+        ip_map = self.data.get(service)
+        if ip_map is None:
+            return None
+
+        host_dict = ip_map.get(ip_address)
+        if host_dict is None:
+            return None
+
+        host = host_dict.copy()
+        host['service'] = service
+        host['ip_address'] = ip_address
+        return host
+
+    def put(self, host):
+        service = host['service']
+        ip_address = host['ip_address']
+
+        ip_map = self.data.get(service)
+        if ip_map is None:
+            ip_map = {}
+            self.data[service] = ip_map
+
+        host_dict = host.copy()
+        del host_dict['service']
+        del host_dict['ip_address']
+
+        ip_map[ip_address] = host_dict
+
+    def delete(self, service, ip_address):
+        ip_map = self.data.get(service)
+        if ip_map is None:
+            return False
+
+        host_dict = ip_map.get(ip_address)
+        if host_dict is None:
+            return False
+
+        del ip_map[ip_address]
+        if len(ip_map) == 0:
+            del self.data[service]
+        return True
+
+
+class LocalFileQueryBackend(QueryBackend):
+    def __init__(self, file=tempfile.TemporaryFile().name):
+        self.backend = MemoryQueryBackend()
+        self.file = file
+        if os.path.isfile(self.file) and os.stat(self.file).st_size > 0:
+            self.backend.data = pickle.load(open(self.file))
+
+    def _save(self):
+        pickle.dump(self.backend.data, open(self.file, 'w'))
+
+    def query(self, service):
+        return self.backend.query(service)
+
+    def query_secondary_index(self, service_repo_name):
+        return self.backend.query_secondary_index(service_repo_name)
+
+    def get(self, service, ip_address):
+        return self.backend.get(service, ip_address)
+
+    def put(self, host):
+        self.backend.put(host)
+        self._save()
+
+    def delete(self, service, ip_address):
+        self.backend.delete(service, ip_address)
+        self._save()
+
+
+class DynamoQueryBackend(QueryBackend):
+    def query(self, service):
+        return self._read_cursor(Host.query(service))
+
+    def query_secondary_index(self, service_repo_name):
+        return self._read_cursor(Host.service_repo_name_index.query(service_repo_name))
+
+    def get(self, service, ip_address):
+        try:
+            host = Host.get(service, ip_address)
+            if host is None:
+                return None
+            return self._pynamo_host_to_dict(host)
+        except Host.DoesNotExist:
+            return None
+
+    def put(self, host):
+        self._dict_to_pynamo_host(host).save()
+
+    def batch_put(self, hosts):
+        with Host.batch_write() as batch:
+            for host in hosts:
+                batch.save(self._dict_to_pynamo_host(host))
+
+    # TODO is all of this pomp and circumstance really necessary to properly delete?
+    #      need to better understand dynamodb
+    def delete(self, service, ip_address):
+        statsd = get_stats('service.host')
+        hosts = list(self._read_cursor(Host.query(service, ip_address__eq=ip_address)))
+        if len(hosts) == 0:
+            logging.error(
+                "Delete called for nonexistent host: service=%s ip=%s" % (service, ip_address)
+            )
+            return False
+        elif len(hosts) > 1:
+            logging.error(
+                "Returned more than 1 result for query %s %s.  Aborting the delete"
+                % (service, ip_address)
+            )
+            return False
+        else:
+            hosts[0].delete()
+            statsd.incr("delete.%s" % service)
+            return True
+
+    def _read_cursor(self, cursor):
+        for host in cursor:
+            yield self._pynamo_host_to_dict(host)
+
+    def _pynamo_host_to_dict(self, host):
+        _host = {}
+        _host['service'] = host.service
+        _host['ip_address'] = host.ip_address
+        _host['service_repo_name'] = host.service_repo_name
+        _host['port'] = host.port
+        _host['revision'] = host.revision
+        _host['last_check_in'] = host.last_check_in
+        _host['tags'] = host.tags
+        return _host
+
+    def _dict_to_pynamo_host(self, host):
+        return Host(service=host['service'],
+                    ip_address=host['ip_address'],
+                    service_repo_name=host['service_repo_name'],
+                    port=host['port'],
+                    revision=host['revision'],
+                    last_check_in=host['last_check_in'],
+                    tags=host['tags'])

--- a/app/services/query.py
+++ b/app/services/query.py
@@ -301,7 +301,7 @@ class DynamoQueryBackend(QueryBackend):
         _host['service_repo_name'] = host.service_repo_name
         _host['port'] = host.port
         _host['revision'] = host.revision
-        _host['last_check_in'] = str(host.last_check_in)
+        _host['last_check_in'] = host.last_check_in
         _host['tags'] = host.tags
         return _host
 

--- a/tests/unit/app/query_test.py
+++ b/tests/unit/app/query_test.py
@@ -1,0 +1,80 @@
+import abc
+import unittest
+from datetime import datetime
+from discovery.app.services import query
+
+
+class QueryBackendTestCase(object):
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def _new_query_backend(self):
+        pass
+
+    def _generate_valid_tags(self):
+        return {'az': 'foo', 'instance_id': 'bar', 'region': 'baz'}
+
+    def test_basic_operations(self):
+        query = self._new_query_backend()
+        self.assertEqual([], list(query.query('wut')))
+
+        host1 = {
+            'service': 'host1',
+            'ip_address': '1.1.1.1',
+            'service_repo_name': 'hosts_repo',
+            'port': 80,
+            'revision': 'host1_rev1',
+            'last_check_in': datetime.utcnow(),
+            'tags': self._generate_valid_tags()
+        }
+
+        host2 = {
+            'service': 'host2',
+            'ip_address': '1.1.1.1',
+            'service_repo_name': host1['service_repo_name'],
+            'port': 90,
+            'revision': 'host2_rev1',
+            'last_check_in': datetime.utcnow(),
+            'tags': self._generate_valid_tags()
+        }
+
+        query.put(host1)
+
+        host1_get = query.get(host1['service'], host1['ip_address'])
+        self.assertEqual(host1, host1_get)
+
+        query.put(host2)
+
+        host1_get = query.get(host1['service'], host1['ip_address'])
+        self.assertEqual(host1, host1_get)
+
+        host2_get = query.get(host2['service'], host2['ip_address'])
+        self.assertEqual(host2, host2_get)
+
+        host2_service = host2['service']
+        host2['service'] = 'bad!!!!'
+
+        self.assertNotEqual(host2, host2_get)
+
+        host2['service'] = host2_service
+        self.assertEqual(host2, host2_get)
+
+        secondary_query = sorted(query.query_secondary_index(host1['service_repo_name']))
+        self.assertEqual([host1, host2], secondary_query)
+
+        query.delete(host2['service'], host2['ip_address'])
+
+        secondary_query = sorted(query.query_secondary_index(host1['service_repo_name']))
+        self.assertEqual([host1], secondary_query)
+
+        self.assertIsNone(query.get(host2['service'], host2['ip_address']))
+
+
+class MemoryQueryBackendTestCase(unittest.TestCase, QueryBackendTestCase):
+    def _new_query_backend(self):
+        return query.MemoryQueryBackend()
+
+
+class LocalDistQueryBackendTestCase(MemoryQueryBackendTestCase):
+    def _new_query_backend(self):
+        return query.LocalFileQueryBackend()


### PR DESCRIPTION
Hello! I want to use envoy, but I don't want to have to depend on AWS to do so.

This factors out the storage backend, and adds in memory and file based implementations.

I wanted to validate the general approach (ie, you'll merge this :) before doing a couple things, which I'd like to do before it is merged:
- add more tests
- split tests and the QueryBackend into their own files

Some future work I'd also like to do, but separate from this PR:
- make statsd optional
- refactor configuration, since right now you have to set a bunch of dynamo db related stuff...
- GCP support as a backend

Would love your thoughts
