### PR TITLE
Bump gevent pin and remove wsgiref pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,6 @@ gunicorn==19.1.1
 gevent==1.0.2
 greenlet==0.4.4
 
-wsgiref==0.1.2
 boto==2.34.0
 
 flake8==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ blinker==1.4
 # Upstream url: http://gunicorn.org
 gunicorn==19.1.1
 
-gevent==1.0.1
+gevent==1.0.2
 greenlet==0.4.4
 
 wsgiref==0.1.2


### PR DESCRIPTION
Using gevent 1.0.1 on Ubuntu 16.04 gave me the exception from https://github.com/gevent/gevent/issues/513. Thankfully, the next patch release fixes it (https://github.com/gevent/gevent/blob/master/CHANGES.rst#release-102).

The wsgiref pin isn't being used at all (I removed it, then installed the requirements, and verified it wasn't in `pip freeze` afterwards).