### PR TITLE
Fix HostService.is_expired TZ bug and add unit test

### DIFF
--- a/app/services/host.py
+++ b/app/services/host.py
@@ -249,12 +249,10 @@ class HostService():
         """
 
         last_check_in = host['last_check_in']
-        now = datetime.datetime.now()
+        now = pytz.utc.localize(datetime.datetime.utcnow())
 
         if not last_check_in.tzinfo:
             last_check_in = pytz.utc.localize(last_check_in)
-        if not now.tzinfo:
-            now = pytz.utc.localize(now)
         # datetime.now(tz.tzutc()) and datetime.utcnow() do not return a tz-aware datetime
         # as a result, we use pytz to localize the timestamp to the UTC timezone
         time_elapsed = (now - last_check_in).total_seconds()


### PR DESCRIPTION
When testing with `InMemory` and `InFile` backends, I noticed that my hosts weren't expiring. Looks like that's because `now` is set to `datetime.now()` in `HostService._is_expired()` but `last_check_in` is set to `datetime.utcnow()` at registration time. 

Looks like there's an attempt to address this by calling `pytz.utc.localize()` but that just assigns tzinfo without changing any of the datetime's fields.

This PR has a unit test that excises this bug and a fix.