### PR TITLE
Fix query and delete bug in sweep

### DIFF
--- a/app/services/query.py
+++ b/app/services/query.py
@@ -127,7 +127,7 @@ class MemoryQueryBackend(QueryBackend):
         if ip_map is None:
             return
 
-        for ip_address, host_dict in ip_map.iteritems():
+        for ip_address, host_dict in ip_map.items():
             _host = host_dict.copy()
             _host['service'] = service
             _host['ip_address'] = ip_address


### PR DESCRIPTION
Sweep is implemented with a query / delete. Delete modifies the underlying store for `InMemory` and `InFile`. Unfortunately, the query implementation assumes the underlying store isn't modified while it's yielding results. So this query/delete pattern leads to explosions for requests that trigger sweeps:

```text
  File "/home/whitney/git/discovery/app/services/query.py", line 130, in query
    for ip_address, host_dict in ip_map.iteritems():
RuntimeError: dictionary changed size during iteration
```