### PR TITLE
Add Connection Pool Settings

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -12,9 +12,6 @@ class CustomPynamoSession(requests.Session):
         self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
 
 
-session_cls = CustomPynamoSession
-
-
 class ServiceRepoNameIndex(GlobalSecondaryIndex):
     class Meta:
         projection = AllProjection()
@@ -33,6 +30,7 @@ class Host(Model):
         table_name = settings.value.DYNAMODB_TABLE_HOSTS
         if settings.value.APPLICATION_ENV == 'development':
             host = settings.value.DYNAMODB_URL
+        session_cls = CustomPynamoSession
 
     service = UnicodeAttribute(hash_key=True)
     ip_address = UnicodeAttribute(range_key=True)

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -7,8 +7,9 @@ from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 
 
 class CustomPynamoSession(requests.Session):
-    super(CustomPynamoSession, self).__init__()
-    self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
+    def __init__(self):
+        super(CustomPynamoSession, self).__init__()
+        self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
 
 
 session_cls = CustomPynamoSession

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -1,7 +1,16 @@
 from .. import settings
+from botocore.vendored import requests
+from botocore.vendored.requests import adapters
 from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, NumberAttribute, UTCDateTimeAttribute, JSONAttribute
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
+
+
+class CustomPynamoSession(requests.Session):
+    super(CustomPynamoSession, self).__init__()
+    self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
+
+session_cls = CustomPynamoSession
 
 
 class ServiceRepoNameIndex(GlobalSecondaryIndex):

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -10,6 +10,7 @@ class CustomPynamoSession(requests.Session):
     def __init__(self):
         super(CustomPynamoSession, self).__init__()
         self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
+        self.mount('https://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
 
 
 class ServiceRepoNameIndex(GlobalSecondaryIndex):

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -10,6 +10,7 @@ class CustomPynamoSession(requests.Session):
     super(CustomPynamoSession, self).__init__()
     self.mount('http://', adapters.HTTPAdapter(pool_maxsize=settings.value.CONNECTION_POOL_SIZE))
 
+
 session_cls = CustomPynamoSession
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -25,7 +25,6 @@ defaults = {
     'BACKEND_STORAGE': 'DynamoDB',
     # Flask cache type, null means no caching.
     'CACHE_TYPE': 'null',
-    # Set the connection pool size
     'CONNECTION_POOL_SIZE': 100
 }
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -24,7 +24,9 @@ defaults = {
     # Supported values: DynamoDB, InMemory, InFile.
     'BACKEND_STORAGE': 'DynamoDB',
     # Flask cache type, null means no caching.
-    'CACHE_TYPE': 'null'
+    'CACHE_TYPE': 'null',
+    # Set the connection pool size
+    'CONNECTION_POOL_SIZE': 100
 }
 
 values = {}


### PR DESCRIPTION
This change creates a configuration setting to set the connection pool limit. The current default for boto is set to 10.

Note that this change also sets the default to be 100, which is more reasonable for Lyft's use cases. This shouldn't be a breaking change though.